### PR TITLE
Indirect inclusion of <functional> fails on Fedora 26

### DIFF
--- a/Qt/zoomableimage.cpp
+++ b/Qt/zoomableimage.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <functional>
 #include "zoomableimage.h"
 #include <QLabel>
 #include <QImage>


### PR DESCRIPTION
Found when building PlanetaryImager on Fedora 26.